### PR TITLE
install.php: ist ffmpeg verfügbar?

### DIFF
--- a/install.php
+++ b/install.php
@@ -3,6 +3,10 @@
 /**
  * Sind die nötigen Shell-Tools verfügbar?
  */
+if (!function_exists('shell_exec')) {
+    throw new rex_functional_exception('shell_exec function is not available. Please check your PHP configuration.');
+}
+
 $shellResponse = shell_exec('command -v ffmpeg');
 if (null === $shellResponse) {
     throw new rex_functional_exception('Missing required shell-command "ffmpeg".');

--- a/install.php
+++ b/install.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Sind die nötigen Shell-Tools verfügbar?
+ */
+$shellResponse = shell_exec('command -v ffmpeg');
+if (null === $shellResponse) {
+    throw new rex_functional_exception('Missing required shell-command "ffmpeg".');
+}


### PR DESCRIPTION
FFMPEG könnte man schon in der Install-php abfragen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a verification check for the availability of the `ffmpeg` shell command during installation.
  
- **Bug Fixes**
	- Implemented error handling to notify users if the `ffmpeg` command is missing.
  
- **Documentation**
	- Updated messages to guide users on checking PHP configuration if the `shell_exec` function is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->